### PR TITLE
Centralize plot-saving checks and messages to ggsave_vector_raster #15

### DIFF
--- a/R/core_diffbind_analyzer.R
+++ b/R/core_diffbind_analyzer.R
@@ -334,12 +334,6 @@ make_diffbind_density_plot <- function(
     stop("A valid file name is required to be specified.")
   }
 
-  #strip off extensions in the filename
-  if (tools::file_ext(save_name) != "") {
-    save_name <- tools::file_path_sans_ext(save_name)
-    warning("file name should not include any extensions, file name changed to: ", save_name)
-  }
-
   if (is.null(save_directory)) {
     save_directory <- getwd()
   }
@@ -367,9 +361,6 @@ make_diffbind_density_plot <- function(
     plot = p
   )
 
-  message("Density Plot is generated successfully. Results saved to: \n",
-          file.path(save_directory, paste0(save_name ,'.png')), " and \n",
-          file.path(save_directory, paste0(save_name ,'.pdf')))
   return(p)
 }
 
@@ -418,11 +409,6 @@ make_diffbind_PCA_plot <- function(
 ){
   if (is.null(figure_title_contrast)) {
     figure_title_contrast <- paste(figure_title_nocontrast, "Differential Binding Sites")
-  }
-  #strip off extensions in the filename
-  if (tools::file_ext(save_name) != "") {
-    save_name <- tools::file_path_sans_ext(save_name)
-    warning("file name should not include any extensions, file base name changed to: ", save_name)
   }
 
   if (is.null(save_directory)) {
@@ -476,10 +462,6 @@ make_diffbind_PCA_plot <- function(
     width = width, height = height, dpi = 600,
     plot = p
   )
-
-  message("PCA Plot is generated successfully. Results saved to: \n",
-          file.path(save_directory, paste0(save_name ,'.png')), " and \n",
-          file.path(save_directory, paste0(save_name ,'.pdf')))
 
   return(p)
 }
@@ -581,11 +563,6 @@ make_diffbind_volcano_plot <- function(
     fdr_threshold=0.05,
     color=c('aquamarine4', 'grey')
 ){
-  #strip off extensions in the filename
-  if (tools::file_ext(save_name) != "") {
-    save_name <- tools::file_path_sans_ext(save_name)
-    warning("file name should not include any extensions, file name changed to: ", save_name)
-  }
 
   if (is.null(save_directory)) {
     save_directory = getwd()
@@ -617,10 +594,6 @@ make_diffbind_volcano_plot <- function(
     width = width, height = height, dpi = 600,
     plot = p
   )
-
-  message("Volcano Plot is generated successfully. Results saved to: \n",
-          file.path(save_directory, paste0(save_name ,'.png')), " and \n",
-          file.path(save_directory, paste0(save_name ,'.pdf')))
 
   return(p)
 }
@@ -796,12 +769,6 @@ make_diffbind_volcano_plot_from_merged <- function(
          paste(missing_cols, collapse = ", "))
   }
 
-  #strip off extensions in the filename
-  if (tools::file_ext(save_name) != "") {
-    save_name <- tools::file_path_sans_ext(save_name)
-    warning("file name should not include any extensions, file name changed to: ", save_name)
-  }
-
   if (length(color) != 2) {
     stop("There should be 2 color choices.")
   }
@@ -904,12 +871,6 @@ make_scatter_plot_from_merged <- function(
   if (length(missing_cols) > 0) {
     stop("The merged data is missing required column(s): ",
          paste(missing_cols, collapse = ", "))
-  }
-
-  #strip off extensions in the filename
-  if (tools::file_ext(save_name) != "") {
-    save_name <- tools::file_path_sans_ext(save_name)
-    warning("file name should not include any extensions, file name changed to: ", save_name)
   }
 
   # exclude rows with NA Values in any column

--- a/R/tools.R
+++ b/R/tools.R
@@ -36,6 +36,10 @@ ggsave_vector_raster <- function(
   raster_device = 'png',
   ...
 ) {
+  if (tools::file_ext(filename) != "") {
+    filename <- tools::file_path_sans_ext(filename)
+    warning("file name should not include any extensions, file name changed to: ", filename)
+  }
 
   ggplot2::ggsave(
     filename = paste0(filename, '.', vector_device),
@@ -51,6 +55,9 @@ ggsave_vector_raster <- function(
      height = height,
      ...
   )
+
+  message("Visualization is generated and saved successfully. Results saved to: \n",
+          paste0(filename ,'.png'), " and \n", paste0(filename ,'.pdf'))
 }
 
 #' clamp
@@ -146,7 +153,7 @@ draw_PCA <- function(data,
     p <- ggplot(pcaData, aes(x = PC1, y = PC2, color = Group)) +
       geom_point(size = 2)
   }
-  p <- p + 
+  p <- p +
     xlab(paste0("PC1: ", VoPC1)) +
     ylab(paste0("PC2: ", VoPC2)) +
     theme_minimal() +

--- a/informal_tests/test_core_diffbind_analyzer.R
+++ b/informal_tests/test_core_diffbind_analyzer.R
@@ -29,7 +29,7 @@ all.sites <- get_diffbind_sites(dba_object=dba.obj, fdr_threshold = 1)
 # Test save_diffbind_sites
 # ==============
 save_diffbind_sites(dba.obj,
-                    save_directory = paste0(config$paths$test_results_dump, "diffbind_files"))
+                    save_directory = file.path(config$paths$test_results_dump, "diffbind_files"))
 
 #===============
 # Test make_diffbind_density_plot
@@ -37,12 +37,12 @@ save_diffbind_sites(dba.obj,
 make_diffbind_density_plot(dba.obj,
                            figure_title="Distribution of Differential Binding Regions",
                            save_name="df_fold_density_h3k27ac",
-                           save_directory = paste0(config$paths$test_results_dump, "diffbind_figures"))
+                           save_directory = file.path(config$paths$test_results_dump, "diffbind_figures"))
 
 make_diffbind_density_plot(dba.obj,
                            figure_title="Distribution of Differential Binding Regions",
                            save_name="df_fold_density_h3k27ac",
-                           save_directory = paste0(config$paths$test_results_dump, "diffbind_figures"),
+                           save_directory = file.path(config$paths$test_results_dump, "diffbind_figures"),
                            xdiff = 1)
 
 #===============
@@ -50,13 +50,13 @@ make_diffbind_density_plot(dba.obj,
 #===============
 make_diffbind_PCA_plot(dba.obj,
                        figure_title_nocontrast="All consensus Peaks: h3k27ac HET vs KO",
-                       save_directory=paste0(config$paths$test_results_dump, "diffbind_figures"),
+                       save_directory=file.path(config$paths$test_results_dump, "diffbind_figures"),
                        save_name="PCA_consensus_vs_diffbind_peaks_kwanlib_h3k27ac")
 
 make_diffbind_PCA_plot(dba.obj,
                        figure_title_nocontrast="All consensus Peaks: h3k27ac",
                        figure_title_contrast="'Differential Binding Peaks: h3k27ac HET vs KO'",
-                       save_directory=paste0(config$paths$test_results_dump, "diffbind_figures"),
+                       save_directory=file.path(config$paths$test_results_dump, "diffbind_figures"),
                        save_name="PCA_consensus_vs_diffbind_peaks_kwanlib_h3k27ac")
 
 #===============
@@ -70,7 +70,7 @@ volcano.sites <- get_diffbind_volcano_data(dba.obj, xdiff=1, ymax=10)
 make_diffbind_volcano_plot(dba.obj,
                            figure_title="h3k27ac cKO vs cHET",
                            save_name="db_volcano_h3k27ac",
-                           save_directory=paste0(config$paths$test_results_dump, "diffbind_figures"),
+                           save_directory=file.path(config$paths$test_results_dump, "diffbind_figures"),
                            point_size = 2,
                            point_alpha = 0.8)
 #================
@@ -81,18 +81,18 @@ options(scipen = 15)
 merged_data <- merge_diffbind_with_DE(dba.obj,
                                       DE_file_path = "/nfs/turbo/umms-kykwan/projects/mll/bulk_rna_seq/tables/mll_edgeR.csv",
                                       tss_file_path = "/nfs/turbo/umms-kykwan/projects/mll/h3k4_me1_cutntag/diffbind_files/TSS.bed",
-                                      save_directory = paste0(config$paths$test_results_dump, "diffbind_figures"))
+                                      save_directory = file.path(config$paths$test_results_dump, "diffbind_figures"))
 
 merged_data <- merge_diffbind_with_DE(dba.obj,
                                       DE_file_path = "/nfs/turbo/umms-kykwan/projects/mll/bulk_rna_seq/tables/mll_edgeR.csv",
                                       tss_file_path = "/nfs/turbo/umms-kykwan/projects/reference/tss/TSS_mm10_gencode.bed",
-                                      save_directory = paste0(config$paths$test_results_dump, "diffbind_figures"))
+                                      save_directory = file.path(config$paths$test_results_dump, "diffbind_figures"))
 #=================
 # Test make_diffbind_volcano_plot_from_merged
 #=================
 make_diffbind_volcano_plot_from_merged(merged_df = merged_data,
                               figure_title=paste0('cKO vs cHet Differential Binding sites', '\n[ color by nearest TSS bulkRNAseq logFC, filtered by bulkRNAseq FDR < 0.05 ]'),
-                              save_directory=paste0(config$paths$test_results_dump, "diffbind_figures"),
+                              save_directory=file.path(config$paths$test_results_dump, "diffbind_figures"),
                               save_name="db_volcano_bulk_color_binary_h3k4me1",
                               xdiff = 2,
                               ymax = 17.5,
@@ -106,7 +106,7 @@ make_diffbind_volcano_plot_from_merged(merged_df = merged_data,
 #=================
 make_scatter_plot_from_merged(merged_df = merged_data,
                               figure_title ="DB sites log2FC vs Nearby Gene RNAseq log2FC",
-                              save_directory=paste0(config$paths$test_results_dump, "diffbind_figures"),
+                              save_directory=file.path(config$paths$test_results_dump, "diffbind_figures"),
                               save_name="db_bulk_scatter_h3k4me1",
                               width = 8,
                               height = 6,
@@ -114,7 +114,7 @@ make_scatter_plot_from_merged(merged_df = merged_data,
 
 make_scatter_plot_from_merged(merged_df = merged_data,
                               figure_title ="DB sites log2FC vs Nearby Gene RNAseq log2FC",
-                              save_directory=paste0(config$paths$test_results_dump, "diffbind_figures"),
+                              save_directory=file.path(config$paths$test_results_dump, "diffbind_figures"),
                               save_name="db_bulk_scatter_no_regression_line_h3k4me1",
                               width = 8,
                               height = 6,

--- a/informal_tests/test_core_edger_analyzer.R
+++ b/informal_tests/test_core_edger_analyzer.R
@@ -8,7 +8,7 @@ devtools::load_all(config$paths$package)
 
 gtf = kwanlibr::get_gtf(config$paths$gtf)
 
-samples = read.table(config$paths$samples_example, header=TRUE, sep=',')
+samples = read.table(config$paths$gene_expression_samples_example, header=TRUE, sep=',')
 Filename = c("1395-ML-1_AGTCAA-TAGATC_S156.tsv",
              "1395-ML-1_AGTTCC-TAGATC_S157.tsv",
              "1395-ML-1_ATGTCA-TAGATC_S158.tsv",
@@ -38,10 +38,10 @@ exp_samples = kwanlibr::label_control_samples(exp_samples, 'Condition', 'ctrl')
 # GTF object
 lrt = kwanlibr::perform_edger(
   exp_samples,
-  filePrefix = config$paths$gene_counts_dir,
+  filePrefix = config$paths$gene_expression_gene_counts_dir,
   idCol = 'Pool.Name',
   gtf=gtf,
-  saveName = paste0(config$paths$test_results_dump, 'edger_lrt')
+  saveName = paste0(config$paths$test_results_dump, '/', 'edger_lrt')
 )
 
 # GTF file path
@@ -50,7 +50,7 @@ lrt = kwanlibr::perform_edger(
   filePrefix = config$paths$gene_counts_dir,
   idCol = 'Pool.Name',
   gtf=config$paths$gtf,
-  saveName = paste0(config$paths$test_results_dump, 'edger_lrt')
+  saveName = paste0(config$paths$test_results_dump, '/', 'edger_lrt')
 )
 
 # no GTF
@@ -58,7 +58,7 @@ lrt = kwanlibr::perform_edger(
   exp_samples,
   filePrefix = config$paths$gene_counts_dir,
   idCol = 'Pool.Name',
-  saveName = paste0(config$paths$test_results_dump, 'edger_lrt')
+  saveName = paste0(config$paths$test_results_dump, '/', 'edger_lrt')
 )
 
 # ===================
@@ -118,13 +118,13 @@ kwanlibr::make_MA_plot(
 # Test make_PCA_plot
 # ==============
 
-make_PCA_plot(lrt, color = c("blue", "red"), figure_title = "Principal Component Analysis", 
+make_PCA_plot(lrt, color = c("blue", "red"), figure_title = "Principal Component Analysis",
               figure_dir = config$paths$test_results_dump, filename = "plot_assigned_color_and_legend")
-make_PCA_plot(lrt, legend = FALSE, figure_title = "Principal Component Analysis", 
+make_PCA_plot(lrt, legend = FALSE, figure_title = "Principal Component Analysis",
               figure_dir = config$paths$test_results_dump, filename = "plot_default_color_no_legend")
-make_PCA_plot(lrt, figure_title = "Principal Component Analysis", 
+make_PCA_plot(lrt, figure_title = "Principal Component Analysis",
               figure_dir = config$paths$test_results_dump, filename = "plot_default_color_and_legend")
-make_PCA_plot(lrt, label = TRUE, figure_title = "Principal Component Analysis", 
+make_PCA_plot(lrt, label = TRUE, figure_title = "Principal Component Analysis",
               figure_dir = config$paths$test_results_dump, filename = "plot_labels_default_color_and_legend")
-make_PCA_plot(lrt, figure_title = "Principal Component Analysis", 
+make_PCA_plot(lrt, figure_title = "Principal Component Analysis",
               figure_dir = config$paths$test_results_dump, filename = "plot_no_labels_default_color_and_legend")


### PR DESCRIPTION
- it will strip off any unnecessary file extensions from the user-provided file name and
- print success messages (with the file saving path
- pass informal test in both diffbind analysis and edger analysis
- modify the save_directory value in test_core_diffbind_analyzer.R so that we don't have to modify `test_results_dump` every time when we switch to another testing script
- updated the file path in config file and in test_core_edger_analyzer.R